### PR TITLE
Config-driven detection labels (#28, #29) — unreleased, blocked on #30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+> **Not released.** These changes are on `main` but deliberately unpublished — there is no GitHub release or tag, so no installation will auto-update to them. See "Known gap" below.
+
+### Fixed
+
+- **Detections that Frigate was configured to produce were silently discarded (#28, #29).** The driver hardcoded which detection labels it subscribed to over MQTT — four object types and nine audio types — while Frigate's actual labels come from its own per-camera configuration. On a live 13-camera system this meant `package` detections at the front door, plus `glass`, `shatter` and `car_alarm`, never reached Control4 at all: no event, no history entry, no log line. Both the subscription set and the handler whitelist are now derived from one label set read from Frigate's config during discovery, so they cannot drift apart. Any label Frigate is configured to detect now reaches Control4, and unrecognised labels fire the generic `Object Detected` / `Audio Detected` events with a properly named history entry rather than being dropped.
+
+- **Three audio history entries were recorded but never displayed in the Control4 app.** `handleAudio()` built its history type by capitalising only the first character, recording `Audio: Fire alarm` while the History agent registration said `Audio: Fire Alarm`. Control4's Navigator renders history only when the recorded type matches a registration exactly, so `fire_alarm`, `glass_breaking` and `car_horn` entries were stored and invisible. Event names, history types and registrations now all derive from one canonical table and cannot disagree.
+
+### Added
+
+- **`Package Detected` and `Package Left` events**, with `PACKAGE_DETECTED` (boolean) and `PACKAGE_LAST_SEEN` (timestamp) variables. Packages persist, so the boolean supports conditions such as "a package is present and nobody has been detected for ten minutes".
+- **`Audio: Car Alarm` event** with `CAR_ALARM_LAST_HEARD`. Deliberately separate from any car-horn concept — a car alarm is a security event.
+- **`glass` and `shatter` both map to `Audio: Glass Breaking`**, sharing `GLASS_BREAKING_LAST_HEARD`; the distinction is acoustic rather than meaningful.
+- **The resolved label sets are logged at INFO on startup**, e.g. `Subscribed to objects: car, package, person | audio: bark, car_alarm, ...`. Every defect above was invisible partly because nothing ever stated what the driver was listening for.
+- **Regression tests for all of the above**, in the committed harnesses that run in CI under LuaJIT.
+
+### Removed
+
+- **BREAKING (unreleased): `Audio: Siren`, `Audio: Car Horn` and `Audio: Music` and their `SIREN_LAST_HEARD`, `CAR_HORN_LAST_HEARD` and `MUSIC_LAST_HEARD` variables.** `/api/labels` on a live system lists only labels Frigate has actually recorded events for, and none of these three appeared — they were invented rather than observed. If a Frigate configuration does emit one of them, the detection still reaches Control4 via the generic `Audio Detected` event with a correctly named history entry, but programming bound to the three removed events would stop firing. Event ids 22–24 are left vacant; no other event was renumbered.
+
+### Known gap — why this is unreleased
+
+Per-camera history registration is lost on any solo camera-driver restart. The NVR only sends each camera its label list during adoption or a manual **Discover Cameras** / **Sync Camera Names** action; its own startup never resends to already-managed cameras. After a camera hot-reload — including the auto-update self-install flow — a previously working camera falls back to registering only the static event types, so `Person Detected`, `Package Detected` and the specific `Audio: *` history types become recorded-but-unregistered, and therefore invisible in the Control4 app.
+
+Candidate fixes, in rough order of preference: have the camera driver persist its label list with `PersistSetValue` and restore it at `OnDriverLateInit`; have the NVR resend config to all managed cameras on its own init; or have the camera request its config from the NVR at init.
+
 ## [0.9.0-rc.1] - 2026-08-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Frigate](https://img.shields.io/badge/Frigate-0.14%2B-blue)
 ![Cameras](https://img.shields.io/badge/Cameras-Unlimited-brightgreen)
 ![Events](https://img.shields.io/badge/Events-29%20Types-purple)
-![Variables](https://img.shields.io/badge/Variables-29-cyan)
+![Variables](https://img.shields.io/badge/Variables-27-cyan)
 ![License](https://img.shields.io/badge/License-MIT-green)
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Frigate](https://img.shields.io/badge/Frigate-0.14%2B-blue)
 ![Cameras](https://img.shields.io/badge/Cameras-Unlimited-brightgreen)
 ![Events](https://img.shields.io/badge/Events-29%20Types-purple)
-![Variables](https://img.shields.io/badge/Variables-27-cyan)
+![Variables](https://img.shields.io/badge/Variables-29-cyan)
 ![License](https://img.shields.io/badge/License-MIT-green)
 
 ---
@@ -348,6 +348,8 @@ These events are available in Composer Pro under each camera's **Events** tab:
 | **Car Left** | All cars have left |
 | **Dog Detected** | A dog appears |
 | **Cat Detected** | A cat appears |
+| **Package Detected** | A package appears |
+| **Package Left** | A previously detected package is no longer present |
 | **Object Detected** | Any object detected (generic catch-all) |
 | **Object Left** | An object type's count drops to zero |
 | **Motion Detected** | Motion is detected |
@@ -363,9 +365,7 @@ These events are available in Composer Pro under each camera's **Events** tab:
 | **Audio: Yell** | Yell audio detected |
 | **Audio: Fire Alarm** | Fire alarm sound detected |
 | **Audio: Glass Breaking** | Glass breaking sound detected |
-| **Audio: Siren** | Siren sound detected |
-| **Audio: Car Horn** | Car horn sound detected |
-| **Audio: Music** | Music audio detected |
+| **Audio: Car Alarm** | Car alarm sound detected |
 | **Audio Detected** | Any audio event detected (generic catch-all) |
 | **Detection Enabled** | Object detection turned on for this camera |
 | **Detection Disabled** | Object detection turned off for this camera |
@@ -382,6 +382,7 @@ Available under each camera for conditional programming:
 | `CAR_DETECTED` | Boolean | "If car detected, open garage" |
 | `DOG_DETECTED` | Boolean | "If dog detected, sound chime" |
 | `CAT_DETECTED` | Boolean | "If cat detected, close pet door" |
+| `PACKAGE_DETECTED` | Boolean | "If package detected, send notification" |
 | `MOTION_DETECTED` | Boolean | "If motion detected, keep lights on" |
 | `CAMERA_ONLINE` | Boolean | "If camera offline, send alert" |
 | `DETECTION_ENABLED` | Boolean | "If detection disabled, send alert" |
@@ -393,6 +394,7 @@ Available under each camera for conditional programming:
 | `CAR_LAST_SEEN` | String | Timestamp of last car detection |
 | `DOG_LAST_SEEN` | String | Timestamp of last dog detection |
 | `CAT_LAST_SEEN` | String | Timestamp of last cat detection |
+| `PACKAGE_LAST_SEEN` | String | "Show when a package last arrived" |
 | `MOTION_LAST_SEEN` | String | Timestamp of last motion |
 | `LOITERING_LAST_SEEN` | String | Timestamp of last loitering event |
 | `AUDIO_LAST_HEARD` | String | Timestamp of last audio event |
@@ -402,9 +404,7 @@ Available under each camera for conditional programming:
 | `YELL_LAST_HEARD` | String | Timestamp of last yell |
 | `FIRE_ALARM_LAST_HEARD` | String | Timestamp of last fire alarm |
 | `GLASS_BREAKING_LAST_HEARD` | String | Timestamp of last glass breaking |
-| `SIREN_LAST_HEARD` | String | Timestamp of last siren |
-| `CAR_HORN_LAST_HEARD` | String | Timestamp of last car horn |
-| `MUSIC_LAST_HEARD` | String | Timestamp of last music detection |
+| `CAR_ALARM_LAST_HEARD` | String | "Show when a car alarm last sounded" |
 
 ---
 
@@ -550,6 +550,20 @@ When a notification fires, the driver attaches the Frigate snapshot of the event
 Events older than the window fall back to the live snapshot, so a motion notification never shows a person detected twenty minutes earlier. The image reflects the most recent object detection within the freshness window regardless of which event type triggered the notification — so a motion or audio notification shortly after a detection will show that detection's snapshot, and only falls back to the live snapshot when no recent detection exists.
 
 > **Note:** The snapshot URL points at the Frigate host on your LAN, exactly as the live snapshot URL always has. Whether images load in notifications received away from home is unchanged by this feature.
+
+### Which detections reach Control4
+
+The driver subscribes to exactly the detection labels your Frigate is configured to produce. It reads `objects.track` and `audio.listen` from Frigate's own configuration — including per-camera overrides — when it discovers cameras.
+
+If you add a label in Frigate (say `package` on a porch camera), restart Frigate and then run **Discover Cameras** in Composer to pick it up. The driver logs what it resolved at startup:
+
+```
+Subscribed to objects: car, package, person | audio: bark, car_alarm, fire_alarm, glass, scream, shatter, speech, yell
+```
+
+Labels with a dedicated event — `person`, `car`, `dog`, `cat`, `package`, and the audio types — fire that event. Any other label fires the generic `Object Detected` / `Audio Detected` event and records history under its own name, so nothing is lost.
+
+If Frigate's configuration cannot be read, the driver falls back to a built-in label list and logs a warning.
 
 ### Debugging
 

--- a/camera-driver/driver.lua
+++ b/camera-driver/driver.lua
@@ -414,13 +414,13 @@ local function handleDetection(tParams)
             recordHistory(friendly .. " left", "Info", friendly .. " Left")
         end
     else
-        -- Generic object
+        local info = labelInfo(objType, "object")
         if count > 0 and eventType == "new" then
             fireEvent("Object Detected")
-            recordHistory(friendly .. " detected", "Info", friendly .. " Detected")
+            recordHistory(info.detected, "Info", info.detected)
         elseif count == 0 then
             fireEvent("Object Left")
-            recordHistory(friendly .. " left", "Info", friendly .. " Left")
+            recordHistory(info.left, "Info", info.left)
         end
     end
 
@@ -505,50 +505,73 @@ end
 -- Audio Detection Handler
 ------------------------------------------------------------------------
 
---- Map Frigate audio type names to event names.
-local AUDIO_EVENTS = {
-    speech         = "Audio: Speech",
-    bark           = "Audio: Bark",
-    scream         = "Audio: Scream",
-    yell           = "Audio: Yell",
-    fire_alarm     = "Audio: Fire Alarm",
-    glass_breaking = "Audio: Glass Breaking",
-    siren          = "Audio: Siren",
-    car_horn       = "Audio: Car Horn",
-    music          = "Audio: Music",
+--- Title-case a Frigate label: "fire_hydrant" -> "Fire Hydrant".
+function friendlyLabel(label)
+    if not label or label == "" then return "Object" end
+    local words = {}
+    for w in tostring(label):gmatch("[^_%s]+") do
+        words[#words + 1] = w:sub(1, 1):upper() .. w:sub(2)
+    end
+    return table.concat(words, " ")
+end
+
+--- Canonical mapping from Frigate label to friendly name, event and variable.
+--- This is the ONLY source for the fired event, the recorded history type and
+--- the registration, so those three cannot disagree (#28, #29).
+OBJECT_LABELS = {
+    person  = { friendly = "Person",  detected = "Person Detected",  left = "Person Left",
+                var_bool = "PERSON_DETECTED",  var_seen = "PERSON_LAST_SEEN",  var_count = "PERSON_COUNT" },
+    car     = { friendly = "Car",     detected = "Car Detected",     left = "Car Left",
+                var_bool = "CAR_DETECTED",     var_seen = "CAR_LAST_SEEN",     var_count = "CAR_COUNT" },
+    dog     = { friendly = "Dog",     detected = "Dog Detected",     left = "Object Left",
+                var_bool = "DOG_DETECTED",     var_seen = "DOG_LAST_SEEN" },
+    cat     = { friendly = "Cat",     detected = "Cat Detected",     left = "Object Left",
+                var_bool = "CAT_DETECTED",     var_seen = "CAT_LAST_SEEN" },
+    package = { friendly = "Package", detected = "Package Detected", left = "Package Left",
+                var_bool = "PACKAGE_DETECTED", var_seen = "PACKAGE_LAST_SEEN" },
 }
+
+AUDIO_LABELS = {
+    speech     = { friendly = "Speech",         event = "Audio: Speech",         var = "SPEECH_LAST_HEARD" },
+    bark       = { friendly = "Bark",           event = "Audio: Bark",           var = "BARK_LAST_HEARD" },
+    scream     = { friendly = "Scream",         event = "Audio: Scream",         var = "SCREAM_LAST_HEARD" },
+    yell       = { friendly = "Yell",           event = "Audio: Yell",           var = "YELL_LAST_HEARD" },
+    fire_alarm = { friendly = "Fire Alarm",     event = "Audio: Fire Alarm",     var = "FIRE_ALARM_LAST_HEARD" },
+    glass      = { friendly = "Glass Breaking", event = "Audio: Glass Breaking", var = "GLASS_BREAKING_LAST_HEARD" },
+    shatter    = { friendly = "Glass Breaking", event = "Audio: Glass Breaking", var = "GLASS_BREAKING_LAST_HEARD" },
+    car_alarm  = { friendly = "Car Alarm",      event = "Audio: Car Alarm",      var = "CAR_ALARM_LAST_HEARD" },
+}
+
+--- Look up a label. Never returns nil: unmapped labels get a generated entry
+--- routed to the generic event, so a detection is never silently dropped.
+function labelInfo(label, kind)
+    if kind == "audio" then
+        local e = AUDIO_LABELS[label]
+        if e then return e end
+        return { friendly = friendlyLabel(label), event = "Audio Detected" }
+    end
+    local e = OBJECT_LABELS[label]
+    if e then return e end
+    local f = friendlyLabel(label)
+    return { friendly = f, detected = f .. " Detected", left = f .. " Left" }
+end
 
 --- Handle audio detection from Frigate.
 --- tParams: { audio_type="speech" }
 local function handleAudio(tParams)
     local audioType = tParams.audio_type or "unknown"
-    local friendly = friendlyObject(audioType:gsub("_", " "))
+    local info = labelInfo(audioType, "audio")
     local ts = timestamp()
 
-    -- Update last-heard timestamps
     setVar(VAR.AUDIO_LAST_HEARD, ts)
-    local AUDIO_LAST_HEARD_VARS = {
-        speech         = VAR.SPEECH_LAST_HEARD,
-        bark           = VAR.BARK_LAST_HEARD,
-        scream         = VAR.SCREAM_LAST_HEARD,
-        yell           = VAR.YELL_LAST_HEARD,
-        fire_alarm     = VAR.FIRE_ALARM_LAST_HEARD,
-        glass_breaking = VAR.GLASS_BREAKING_LAST_HEARD,
-        siren          = VAR.SIREN_LAST_HEARD,
-        car_horn       = VAR.CAR_HORN_LAST_HEARD,
-        music          = VAR.MUSIC_LAST_HEARD,
-    }
-    if AUDIO_LAST_HEARD_VARS[audioType] then
-        setVar(AUDIO_LAST_HEARD_VARS[audioType], ts)
-    end
+    if info.var and VAR[info.var] then setVar(VAR[info.var], ts) end
 
-    local eventName = AUDIO_EVENTS[audioType]
-    if eventName then
-        fireEvent(eventName)
-    end
+    if info.event ~= "Audio Detected" then fireEvent(info.event) end
     fireEvent("Audio Detected")
-    recordHistory("Audio: " .. friendly, "Info", "Audio: " .. friendly)
-    C4:UpdateProperty(PROP_LAST_EVENT, "Audio: " .. friendly .. " — " .. ts)
+
+    local label = "Audio: " .. info.friendly
+    recordHistory(label, "Info", label)
+    C4:UpdateProperty(PROP_LAST_EVENT, label .. " — " .. ts)
 end
 
 ------------------------------------------------------------------------

--- a/camera-driver/driver.lua
+++ b/camera-driver/driver.lua
@@ -657,8 +657,13 @@ function GetNotificationAttachmentURL(idBinding, tParams)
     return url
 end
 
---- Register detection events with the History Agent for push notifications.
-local function registerNotificationEvents()
+--- Register the history event types this camera can emit.
+--- Called with no arguments at init (static set only); called again with the
+--- camera's own labels when the NVR sends them, so registration matches what
+--- this specific camera can actually produce (#28, #29).
+--- The complete set is always sent in ONE call, which is correct whether
+--- C4:RegisterEvents replaces or accumulates.
+local function registerNotificationEvents(objectLabels, audioLabels)
     local proxyDevices = C4:GetProxyDevices()
     if type(proxyDevices) ~= "table" then
         log(LOG_WARNING, "RegisterEvents skipped — GetProxyDevices returned no table; "
@@ -679,27 +684,31 @@ local function registerNotificationEvents()
 
     -- Every event type passed to recordHistory() must be registered here, or
     -- Navigator has no registration to match the stored record against.
-    local types = {
-        -- Object detection
-        "Person Detected", "Person Left",
-        "Car Detected",    "Car Left",
-        "Dog Detected",    "Dog Left",
-        "Cat Detected",    "Cat Left",
-        "Object Detected", "Object Left",
-        "Package Detected", "Package Left",
-        -- Motion / zones / loitering
-        "Motion Detected", "Motion Stopped",
-        "Zone Entered",    "Zone Exited",
-        "Loitering Detected",
-        -- Health
-        "Camera Online",   "Camera Offline",
-        -- Audio detection
-        "Audio: Speech", "Audio: Bark", "Audio: Scream", "Audio: Yell",
-        "Audio: Fire Alarm", "Audio: Glass Breaking", "Audio: Car Alarm",
-        -- State changes
-        "Detection Enabled", "Detection Disabled",
-        "Recording Enabled", "Recording Disabled",
-    }
+    local seen, types = {}, {}
+    local function addType(t)
+        if t and t ~= "" and not seen[t] then seen[t] = true; types[#types + 1] = t end
+    end
+
+    -- Static types, always registered.
+    addType("Object Detected")   addType("Object Left")
+    addType("Motion Detected")   addType("Motion Stopped")
+    addType("Zone Entered")      addType("Zone Exited")
+    addType("Loitering Detected")
+    addType("Camera Online")     addType("Camera Offline")
+    addType("Audio Detected")
+    addType("Detection Enabled")  addType("Detection Disabled")
+    addType("Recording Enabled")  addType("Recording Disabled")
+
+    -- This camera's own labels.
+    for _, l in ipairs(objectLabels or {}) do
+        local info = labelInfo(l, "object")
+        addType(info.detected)
+        addType(info.left)
+    end
+    for _, l in ipairs(audioLabels or {}) do
+        local info = labelInfo(l, "audio")
+        addType("Audio: " .. info.friendly)
+    end
 
     local typeList = ""
     for _, t in ipairs(types) do
@@ -875,6 +884,17 @@ function ExecuteCommand(sCommand, tParams)
                 C4:UpdateProperty(PROP_SUB_STREAM, tParams.use_sub_stream)
             end
             updateProxy()
+
+            local function splitLabels(s)
+                local out = {}
+                for v in tostring(s or ""):gmatch("[^,]+") do out[#out + 1] = v end
+                return out
+            end
+            local objL = splitLabels(tParams.object_labels)
+            local audL = splitLabels(tParams.audio_labels)
+            log(LOG_DEBUG, "Labels for this camera — objects: " .. tostring(tParams.object_labels)
+                .. " | audio: " .. tostring(tParams.audio_labels))
+            registerNotificationEvents(objL, audL)
         end
     elseif sCommand == "FRIGATE_DETECTION" then
         handleDetection(tParams or {})

--- a/camera-driver/driver.lua
+++ b/camera-driver/driver.lua
@@ -699,15 +699,35 @@ local function registerNotificationEvents(objectLabels, audioLabels)
     addType("Detection Enabled")  addType("Detection Disabled")
     addType("Recording Enabled")  addType("Recording Disabled")
 
-    -- This camera's own labels.
-    for _, l in ipairs(objectLabels or {}) do
-        local info = labelInfo(l, "object")
-        addType(info.detected)
-        addType(info.left)
+    -- This camera's own labels. An empty or absent list means "unknown" —
+    -- Frigate was unreachable, or this camera isn't in Frigate's config yet —
+    -- not "this camera detects nothing". Register the full canonical set in
+    -- that case, mirroring the NVR side's "widest safe set on failure"
+    -- fallback; a camera in this state still receives detections through the
+    -- NVR's wildcard MQTT subscriptions, and under-registering means those
+    -- get recorded but never rendered in the Control4 app (final-fix Finding
+    -- B). When real labels are supplied, keep the precise per-camera set.
+    if objectLabels and #objectLabels > 0 then
+        for _, l in ipairs(objectLabels) do
+            local info = labelInfo(l, "object")
+            addType(info.detected)
+            addType(info.left)
+        end
+    else
+        for _, info in pairs(OBJECT_LABELS) do
+            addType(info.detected)
+            addType(info.left)
+        end
     end
-    for _, l in ipairs(audioLabels or {}) do
-        local info = labelInfo(l, "audio")
-        addType("Audio: " .. info.friendly)
+    if audioLabels and #audioLabels > 0 then
+        for _, l in ipairs(audioLabels) do
+            local info = labelInfo(l, "audio")
+            addType("Audio: " .. info.friendly)
+        end
+    else
+        for _, info in pairs(AUDIO_LABELS) do
+            addType("Audio: " .. info.friendly)
+        end
     end
 
     local typeList = ""

--- a/camera-driver/driver.lua
+++ b/camera-driver/driver.lua
@@ -116,9 +116,11 @@ local VAR = {
     YELL_LAST_HEARD           = "YELL_LAST_HEARD",
     FIRE_ALARM_LAST_HEARD     = "FIRE_ALARM_LAST_HEARD",
     GLASS_BREAKING_LAST_HEARD = "GLASS_BREAKING_LAST_HEARD",
-    SIREN_LAST_HEARD          = "SIREN_LAST_HEARD",
-    CAR_HORN_LAST_HEARD       = "CAR_HORN_LAST_HEARD",
-    MUSIC_LAST_HEARD          = "MUSIC_LAST_HEARD",
+    CAR_ALARM_LAST_HEARD      = "CAR_ALARM_LAST_HEARD",
+
+    -- Package (persistent, so boolean + last-seen like other objects)
+    PACKAGE_DETECTED  = "PACKAGE_DETECTED",
+    PACKAGE_LAST_SEEN = "PACKAGE_LAST_SEEN",
 }
 
 -- Last Frigate event seen for this camera, used to attach that event's
@@ -214,9 +216,11 @@ local function initVariables()
     C4:AddVariable(VAR.YELL_LAST_HEARD,           "", "STRING")
     C4:AddVariable(VAR.FIRE_ALARM_LAST_HEARD,     "", "STRING")
     C4:AddVariable(VAR.GLASS_BREAKING_LAST_HEARD, "", "STRING")
-    C4:AddVariable(VAR.SIREN_LAST_HEARD,          "", "STRING")
-    C4:AddVariable(VAR.CAR_HORN_LAST_HEARD,       "", "STRING")
-    C4:AddVariable(VAR.MUSIC_LAST_HEARD,          "", "STRING")
+    C4:AddVariable(VAR.CAR_ALARM_LAST_HEARD,      "", "STRING")
+
+    -- Package
+    C4:AddVariable(VAR.PACKAGE_DETECTED,  "false", "BOOL")
+    C4:AddVariable(VAR.PACKAGE_LAST_SEEN, "", "STRING")
 end
 
 --- Update a driver variable by name. Never let a bad variable name abort
@@ -332,14 +336,17 @@ local EVENT_IDS = {
     ["Audio: Yell"]          = 19,
     ["Audio: Fire Alarm"]    = 20,
     ["Audio: Glass Breaking"] = 21,
-    ["Audio: Siren"]         = 22,
-    ["Audio: Car Horn"]      = 23,
-    ["Audio: Music"]         = 24,
+    -- 22-24 vacant: Audio: Siren / Car Horn / Music removed (#28, #29) —
+    -- Frigate has never emitted these labels. Ids left unassigned rather
+    -- than reused so no existing event identity moves.
     ["Audio Detected"]       = 25,
     ["Detection Enabled"]    = 26,
     ["Detection Disabled"]   = 27,
     ["Recording Enabled"]    = 28,
     ["Recording Disabled"]   = 29,
+    ["Package Detected"]     = 30,
+    ["Package Left"]         = 31,
+    ["Audio: Car Alarm"]     = 32,
 }
 
 --- Fire a named event declared in driver.xml <events>.
@@ -410,6 +417,18 @@ local function handleDetection(tParams)
             fireEvent("Object Detected")
             recordHistory(friendly .. " detected", "Info", friendly .. " Detected")
         elseif count == 0 then
+            fireEvent("Object Left")
+            recordHistory(friendly .. " left", "Info", friendly .. " Left")
+        end
+    elseif objType == "package" then
+        setVar(VAR.PACKAGE_DETECTED, count > 0 and "true" or "false")
+        if count > 0 then setVar(VAR.PACKAGE_LAST_SEEN, ts) end
+        if count > 0 and eventType == "new" then
+            fireEvent("Package Detected")
+            fireEvent("Object Detected")
+            recordHistory(friendly .. " detected", "Info", friendly .. " Detected")
+        elseif count == 0 then
+            fireEvent("Package Left")
             fireEvent("Object Left")
             recordHistory(friendly .. " left", "Info", friendly .. " Left")
         end
@@ -667,6 +686,7 @@ local function registerNotificationEvents()
         "Dog Detected",    "Dog Left",
         "Cat Detected",    "Cat Left",
         "Object Detected", "Object Left",
+        "Package Detected", "Package Left",
         -- Motion / zones / loitering
         "Motion Detected", "Motion Stopped",
         "Zone Entered",    "Zone Exited",
@@ -675,8 +695,7 @@ local function registerNotificationEvents()
         "Camera Online",   "Camera Offline",
         -- Audio detection
         "Audio: Speech", "Audio: Bark", "Audio: Scream", "Audio: Yell",
-        "Audio: Fire Alarm", "Audio: Glass Breaking", "Audio: Siren",
-        "Audio: Car Horn", "Audio: Music",
+        "Audio: Fire Alarm", "Audio: Glass Breaking", "Audio: Car Alarm",
         -- State changes
         "Detection Enabled", "Detection Disabled",
         "Recording Enabled", "Recording Disabled",

--- a/camera-driver/driver.xml
+++ b/camera-driver/driver.xml
@@ -275,21 +275,6 @@
       <description>Glass breaking was detected by Frigate audio detection.</description>
     </event>
     <event>
-      <id>22</id>
-      <name>Audio: Siren</name>
-      <description>A siren was detected by Frigate audio detection.</description>
-    </event>
-    <event>
-      <id>23</id>
-      <name>Audio: Car Horn</name>
-      <description>A car horn was detected by Frigate audio detection.</description>
-    </event>
-    <event>
-      <id>24</id>
-      <name>Audio: Music</name>
-      <description>Music was detected by Frigate audio detection.</description>
-    </event>
-    <event>
       <id>25</id>
       <name>Audio Detected</name>
       <description>Any audio event was detected (generic catch-all).</description>
@@ -313,6 +298,21 @@
       <id>29</id>
       <name>Recording Disabled</name>
       <description>Recording was disabled on this camera.</description>
+    </event>
+    <event>
+      <id>30</id>
+      <name>Package Detected</name>
+      <description>A package was detected by Frigate object detection.</description>
+    </event>
+    <event>
+      <id>31</id>
+      <name>Package Left</name>
+      <description>A previously detected package is no longer present.</description>
+    </event>
+    <event>
+      <id>32</id>
+      <name>Audio: Car Alarm</name>
+      <description>A car alarm was detected by Frigate audio detection.</description>
     </event>
   </events>
 </devicedata>

--- a/docs/superpowers/RESUME-config-driven-labels.md
+++ b/docs/superpowers/RESUME-config-driven-labels.md
@@ -1,0 +1,95 @@
+# RESUME: config-driven detection labels
+
+**Paused:** 2026-08-15, by choice, for roughly a week.
+**Branch:** `feature/28-29-config-driven-labels` — pushed, CI green, **not merged**.
+**PR:** [#31](https://github.com/mattstein111/control4-frigate/pull/31)
+**Issues:** [#28](https://github.com/mattstein111/control4-frigate/issues/28), [#29](https://github.com/mattstein111/control4-frigate/issues/29) (fixed, open until released) · [#30](https://github.com/mattstein111/control4-frigate/issues/30) (blocks release)
+
+To resume, say "pick up the config-driven labels work". Read this file first; it is the single source of state.
+
+---
+
+## Where things stand
+
+The work is **complete, reviewed and CI-green**, but deliberately unreleased and unmerged.
+
+| | |
+|---|---|
+| Released? | **No.** No tag, no GitHub release. Camera driver v44, NVR v49, `DRIVER_RELEASE` `v0.9.0-rc.1` — all unchanged. |
+| On `main`? | **No.** `main` is untouched. The branch exists only as PR #31. |
+| Can users get it? | **No.** The auto-updater installs GitHub *releases*; there is no release. |
+| Tests | 55 assertions (`nvr_test.lua`) + 79 (`driver_test.lua`), green locally and on CI. |
+
+### Verify the state in one command
+
+```sh
+git fetch && git checkout feature/28-29-config-driven-labels
+luajit test/nvr_test.lua nvr-driver/driver.lua      # expect ALL PASS
+luajit test/driver_test.lua camera-driver/driver.lua # expect ALL PASS
+./build.sh all                                       # expect both .c4z
+grep -o "<version>[0-9]*</version>" camera-driver/driver.xml nvr-driver/driver.xml
+grep -n 'DRIVER_RELEASE  =' nvr-driver/driver.lua    # expect v0.9.0-rc.1
+```
+
+**Use `luajit`, never the system `lua`.** DriverWorks runs LuaJIT (Lua 5.1 semantics); the local `lua` is 5.5 and will not even load `nvr-driver/driver.lua`.
+
+---
+
+## What this branch did
+
+The driver hardcoded which Frigate detection labels it subscribed to over MQTT, in two independent places per detection kind, while Frigate's real labels come from its own per-camera config. They drifted silently: on the reference system `package`, `glass`, `shatter` and `car_alarm` detections were discarded entirely, while the driver subscribed to four labels Frigate has never emitted.
+
+Now both the subscription set and the handler whitelist are generated from one config-resolved label set, a canonical mapping table feeds the event / history type / registration alike, unmapped labels reach a generic path instead of being dropped, and registration is per-camera. `package` and `car_alarm` became first-class; `Audio: Siren` / `Car Horn` / `Music` were removed as a breaking change.
+
+Full detail is in PR #31 and in `docs/superpowers/specs/2026-08-14-config-driven-detection-labels-design.md`.
+
+---
+
+## Do this first when you return
+
+### 1. #30 — the only thing blocking release
+
+Per-camera history registration is lost when a camera driver restarts on its own, because the NVR only sends a camera its labels during adoption or a manual **Discover Cameras**. Its own `OnDriverLateInit` never resends to already-managed cameras.
+
+**Severity is now reduced.** An empty label list registers the *full canonical set*, so `person`, `car`, `dog`, `cat`, `package` and every canonical `Audio: *` recover after a restart. Only **non-canonical** labels are still affected — `bicycle`, `truck`, or Frigate+ `amazon` / `ups` / `fedex`.
+
+**The fix, roughly 30 lines:** in `camera-driver/driver.lua`, persist the label list with `C4:PersistSetValue` when `SET_FRIGATE_CONFIG` arrives, and restore it in `OnDriverLateInit` before calling `registerNotificationEvents`. That recovers the exact per-camera set rather than the canonical superset, and removes the reliance on registering more types than a camera can emit.
+
+Needs a regression test: a camera restarting with no fresh `SET_FRIGATE_CONFIG` still ends up with its full registration.
+
+### 2. Hardware test
+
+Nothing on this branch has run on the live Control4 system. Worth confirming before any release:
+
+- A `package` detection at `front_door` fires `Package Detected`, sets `PACKAGE_DETECTED`, and **appears in the app's history**
+- The startup log line reports the resolved sets, e.g. `Subscribed to objects: car, package, person | audio: bark, car_alarm, …`
+- Adding a label in Frigate, restarting Frigate, and running **Discover Cameras** makes that label's events flow without a driver release
+
+### 3. Then decide on merge and release
+
+Merging is safe whenever — no release results from it. Release only after #30 and the hardware test.
+
+---
+
+## Deferred minor findings
+
+None block merge. Recorded here because the SDD ledger that held them was deleted with its workspace.
+
+| Finding | Where | Why deferred |
+|---|---|---|
+| `friendlyObject` is still a second source for history types, used in five hardcoded `handleDetection` branches (`camera-driver/driver.lua:164`, used ~`:372`) | camera driver | Harmless **only** because those five labels are single-word. Add a multi-word first-class label such as `license_plate` and the title-case bug from #28 returns. Worth folding into the next change that touches those branches. |
+| No test exercises `sendCameraConfig`'s third `useSub` parameter | `test/nvr_test.lua` | Dropping the per-camera override still passes the suite (proven by mutation). Correctness verified by code reading. Pre-existing coverage gap. |
+| Object labels bypass the audio telemetry filter in `buildSubscriptionTopics` | nvr driver | An object label literally named `rms` would produce a matching zone topic. The handler drops it, so #23 does **not** regress. Noted for symmetry only. |
+| Three `*ForTest` accessors ship in the production `.c4z` — `getFallbackLabels`, `sendCameraConfigForTest`, `handleMQTTForTest` | both drivers | Legitimate test seams for `local` functions, inert in the C4 sandbox. Flagged so the call stays deliberate. |
+
+---
+
+## Gotchas that cost real time on this codebase
+
+- **Tests run under `luajit`.** The system `lua` is 5.5 and cannot load the NVR driver at all.
+- **Count variables with `grep -cE '^\s*C4:AddVariable\('` → 27.** A bare `grep -c "C4:AddVariable"` returns 29 because two comment lines mention the API name. That miscount already propagated into a badge and a spec once.
+- **`C4:SendToDevice` serialises every param as a string.** Tables do not survive; `"false"` is truthy in Lua.
+- **`C4:RecordHistory` takes four arguments.** The documented fifth metadata table stops the record being stored on OS 3.4.3.
+- **Recorded history must match a `C4:RegisterEvents` registration exactly**, category `Cameras`, subcategory `Frigate`, or Navigator silently will not display it.
+- **Never subscribe to `frigate/+/audio/rms` or `dBFS`** — ~1 message/second/camera.
+- **"The tests pass" was not sufficient evidence here.** Reviewers repeatedly found tests that passed while the code was wrong, and the most serious defect on this branch — resolved labels never reaching the MQTT subscription list, which would have made the whole feature inert for any label outside the fallback — survived seven clean per-task reviews and only fell to the whole-branch pass. Mutation-test anything load-bearing.

--- a/docs/superpowers/specs/2026-08-14-config-driven-detection-labels-design.md
+++ b/docs/superpowers/specs/2026-08-14-config-driven-detection-labels-design.md
@@ -158,7 +158,7 @@ Event IDs 22–24 are left **vacant rather than reused**. Renumbering existing e
 
 Packages persist, so they get boolean state — enabling "a package is present and nobody has been detected for 10 minutes". Audio types are momentary and follow the existing timestamp-only pattern.
 
-Net counts are unchanged: 29 events (three added, three removed) and 29 variables. The README badge claims 27 variables and is already stale — correct it to 29 in the same change.
+Net counts are unchanged: **29 events** and **27 variables** (three added, three removed in each). Note: `grep -c "C4:AddVariable"` reports 29 because two comment lines mention the API name — count actual call sites with `grep -cE '^\s*C4:AddVariable\('`. The README badge correctly reads 27.
 
 ### 7. Fallback and failure handling
 

--- a/nvr-driver/driver.lua
+++ b/nvr-driver/driver.lua
@@ -263,6 +263,53 @@ local function jsonAfterObject(json)
     return json:match('"after"%s*:%s*(%b{})')
 end
 
+--- Extract a JSON string array like "listen":["a","b"] into a Lua array.
+local function jsonStringArray(json, key)
+    local body = json:match('"' .. key .. '"%s*:%s*%[([^%]]*)%]')
+    if not body then return nil end
+    local out = {}
+    for v in body:gmatch('"([^"]+)"') do out[#out + 1] = v end
+    return out
+end
+
+--- Parse the detection labels Frigate is configured to produce.
+--- Returns objectUnion, audioUnion, perCamera — unions are sorted arrays;
+--- perCamera maps camera name to { objects = {...}, audio = {...} }.
+--- Returns nil if the payload has no parseable cameras block (#28, #29).
+function parseDetectionLabels(payload)
+    if type(payload) ~= "string" or payload == "" then return nil end
+
+    local camerasBlock = payload:match('"cameras"%s*:%s*(%b{})')
+    if not camerasBlock then return nil end
+
+    local objSet, audSet, perCamera = {}, {}, {}
+
+    for camName, camBody in camerasBlock:gmatch('"([%w_%-]+)"%s*:%s*(%b{})') do
+        local objBlock = camBody:match('"objects"%s*:%s*(%b{})')
+        local audBlock = camBody:match('"audio"%s*:%s*(%b{})')
+        local objs = objBlock and jsonStringArray(objBlock, "track") or {}
+        local auds = audBlock and jsonStringArray(audBlock, "listen") or {}
+
+        for _, l in ipairs(objs) do objSet[l] = true end
+        for _, l in ipairs(auds) do audSet[l] = true end
+        perCamera[camName] = { objects = objs, audio = auds }
+    end
+
+    local function sortedKeys(set)
+        local out = {}
+        for k in pairs(set) do out[#out + 1] = k end
+        table.sort(out)
+        return out
+    end
+
+    for _, info in pairs(perCamera) do
+        table.sort(info.objects)
+        table.sort(info.audio)
+    end
+
+    return sortedKeys(objSet), sortedKeys(audSet), perCamera
+end
+
 ------------------------------------------------------------------------
 -- MQTT Client (C4:MQTT API — OS 3.3+)
 ------------------------------------------------------------------------

--- a/nvr-driver/driver.lua
+++ b/nvr-driver/driver.lua
@@ -330,6 +330,11 @@ local FALLBACK_OBJECT_LABELS = { "person", "car", "dog", "cat", "package" }
 local FALLBACK_AUDIO_LABELS  = { "speech", "bark", "scream", "yell", "fire_alarm",
                                  "glass", "shatter", "car_alarm" }
 
+--- Test accessor: expose the fallback label sets without making them global state.
+function getFallbackLabels()
+    return FALLBACK_OBJECT_LABELS, FALLBACK_AUDIO_LABELS
+end
+
 RESOLVED_OBJECT_LABELS = FALLBACK_OBJECT_LABELS
 RESOLVED_AUDIO_LABELS  = FALLBACK_AUDIO_LABELS
 

--- a/nvr-driver/driver.lua
+++ b/nvr-driver/driver.lua
@@ -314,44 +314,59 @@ end
 -- MQTT Client (C4:MQTT API — OS 3.3+)
 ------------------------------------------------------------------------
 
--- Frigate audio-detection types. Anything outside this set on frigate/<cam>/audio/<type>
--- is telemetry (rms, dBFS, future additions) and must be ignored.
-AUDIO_DETECTION_TYPES = {
-    speech=true, bark=true, scream=true, yell=true, fire_alarm=true,
-    glass_breaking=true, siren=true, car_horn=true, music=true,
-}
+-- Audio telemetry that must never be subscribed to: Frigate publishes these
+-- ~1/second per camera and they would flood Last Event (issue #23).
+local AUDIO_TELEMETRY = { rms = true, dBFS = true, state = true }
+
+-- Fallback label sets, used when the Frigate config cannot be read. These
+-- reproduce the pre-config-driven behaviour exactly.
+local FALLBACK_OBJECT_LABELS = { "person", "car", "dog", "cat" }
+local FALLBACK_AUDIO_LABELS  = { "speech", "bark", "scream", "yell", "fire_alarm" }
+
+RESOLVED_OBJECT_LABELS = FALLBACK_OBJECT_LABELS
+RESOLVED_AUDIO_LABELS  = FALLBACK_AUDIO_LABELS
+
+-- Derived from RESOLVED_AUDIO_LABELS by setResolvedLabels(); never edited
+-- directly, so it cannot drift from the subscription list.
+AUDIO_DETECTION_TYPES = {}
+
+--- Assign the resolved label sets and rebuild the derived whitelist.
+function setResolvedLabels(objectLabels, audioLabels)
+    if objectLabels and #objectLabels > 0 then RESOLVED_OBJECT_LABELS = objectLabels end
+    if audioLabels  and #audioLabels  > 0 then RESOLVED_AUDIO_LABELS  = audioLabels  end
+    AUDIO_DETECTION_TYPES = {}
+    for _, l in ipairs(RESOLVED_AUDIO_LABELS) do
+        if not AUDIO_TELEMETRY[l] then AUDIO_DETECTION_TYPES[l] = true end
+    end
+end
+setResolvedLabels(FALLBACK_OBJECT_LABELS, FALLBACK_AUDIO_LABELS)
+
+--- Build the full MQTT topic list for the given resolved labels.
+function buildSubscriptionTopics(objectLabels, audioLabels)
+    local topics = {
+        "frigate/available",
+        "frigate/events",
+        "frigate/+/motion",
+        "frigate/+/detect/state",
+        "frigate/+/recordings/state",
+    }
+    for _, l in ipairs(objectLabels or {}) do
+        topics[#topics + 1] = "frigate/+/" .. l          -- object counts
+        topics[#topics + 1] = "frigate/+/+/" .. l        -- zone counts
+    end
+    for _, l in ipairs(audioLabels or {}) do
+        if not AUDIO_TELEMETRY[l] then
+            topics[#topics + 1] = "frigate/+/audio/" .. l
+        end
+    end
+    return topics
+end
 
 --- Subscribe to all Frigate MQTT topics.
 local function subscribeFrigateTopics()
     if not mqttClient then return end
 
-    local topics = {
-        "frigate/available",
-        "frigate/events",
-        -- Per-camera object counts
-        "frigate/+/person",
-        "frigate/+/car",
-        "frigate/+/dog",
-        "frigate/+/cat",
-        "frigate/+/motion",
-        -- Zone events: frigate/<camera>/<zone>/<object>
-        "frigate/+/+/person",
-        "frigate/+/+/car",
-        "frigate/+/+/dog",
-        "frigate/+/+/cat",
-        -- Audio detection events (whitelist — excludes rms/dBFS telemetry that would flood Last Event)
-        "frigate/+/audio/speech",
-        "frigate/+/audio/bark",
-        "frigate/+/audio/scream",
-        "frigate/+/audio/yell",
-        "frigate/+/audio/fire_alarm",
-        "frigate/+/audio/glass_breaking",
-        "frigate/+/audio/siren",
-        "frigate/+/audio/car_horn",
-        "frigate/+/audio/music",
-        "frigate/+/detect/state",
-        "frigate/+/recordings/state",
-    }
+    local topics = buildSubscriptionTopics(RESOLVED_OBJECT_LABELS, RESOLVED_AUDIO_LABELS)
 
     for _, topic in ipairs(topics) do
         mqttClient:Subscribe(topic, 1)
@@ -359,6 +374,8 @@ local function subscribeFrigateTopics()
     end
 
     log(LOG_INFO, "Subscribed to all Frigate MQTT topics")
+    log(LOG_INFO, "Subscribed to objects: " .. table.concat(RESOLVED_OBJECT_LABELS, ", ")
+        .. " | audio: " .. table.concat(RESOLVED_AUDIO_LABELS, ", "))
 end
 
 --- Parse MQTT topic into segments.
@@ -487,7 +504,11 @@ local function onMQTTMessage(obj, msgId, topic, payload, qos, retain)
     -- frigate/<camera>/<object>
     if #segments == 3 then
         local objType = segments[3]
-        if objType == "person" or objType == "car" or objType == "dog" or objType == "cat" then
+        local tracked = false
+        for _, l in ipairs(RESOLVED_OBJECT_LABELS) do
+            if l == objType then tracked = true break end
+        end
+        if tracked then
             local count = tonumber(payload) or 0
             local key = camName .. "/" .. objType
             local prevCount = prevCounts[key] or 0
@@ -514,7 +535,11 @@ local function onMQTTMessage(obj, msgId, topic, payload, qos, retain)
     if #segments == 4 then
         local zone = segments[3]
         local objType = segments[4]
-        if objType == "person" or objType == "car" or objType == "dog" or objType == "cat" then
+        local tracked = false
+        for _, l in ipairs(RESOLVED_OBJECT_LABELS) do
+            if l == objType then tracked = true break end
+        end
+        if tracked then
             local count = tonumber(payload) or 0
             local zoneKey = camName .. "/" .. zone .. "/" .. objType
             local prevCount = prevCounts[zoneKey] or 0
@@ -639,6 +664,14 @@ local function fetchCameras(callback)
             setStatus("API Error: " .. ((strError and strError ~= "") and strError or ("HTTP " .. tostring(responseCode))))
             if callback then callback(false, {}) end
             return
+        end
+
+        local objU, audU = parseDetectionLabels(strData)
+        if objU then
+            setResolvedLabels(objU, audU)
+        else
+            log(LOG_WARNING, "Could not read detection labels from Frigate config — "
+                .. "falling back to the built-in label list; some detections may not reach Control4")
         end
 
         local cameraNames = {}
@@ -1430,4 +1463,9 @@ function OnDriverDestroyed()
         C4:KillTimer(UPDATE_CHECK_TIMER)
         UPDATE_CHECK_TIMER = nil
     end
+end
+
+--- Test accessor: route a raw MQTT message the way the broker callback does.
+function handleMQTTForTest(topic, payload)
+    return onMQTTMessage(nil, 0, topic, payload, 1, false)
 end

--- a/nvr-driver/driver.lua
+++ b/nvr-driver/driver.lua
@@ -353,6 +353,9 @@ function setResolvedLabels(objectLabels, audioLabels)
 end
 setResolvedLabels(FALLBACK_OBJECT_LABELS, FALLBACK_AUDIO_LABELS)
 
+-- Per-camera resolved labels, populated during discovery. Keyed by camera name.
+RESOLVED_PER_CAMERA = {}
+
 --- Build the full MQTT topic list for the given resolved labels.
 function buildSubscriptionTopics(objectLabels, audioLabels)
     local topics = {
@@ -678,9 +681,10 @@ local function fetchCameras(callback)
             return
         end
 
-        local objU, audU = parseDetectionLabels(strData)
+        local objU, audU, perCam = parseDetectionLabels(strData)
         if objU then
             setResolvedLabels(objU, audU)
+            RESOLVED_PER_CAMERA = perCam or {}
         else
             log(LOG_WARNING, "Could not read detection labels from Frigate config — "
                 .. "falling back to the built-in label list; some detections may not reach Control4")
@@ -845,6 +849,25 @@ local function adoptOrphanCameras()
     end
 end
 
+--- Send configuration to a camera driver, including that camera's own
+--- detection labels. SendToDevice serialises params as strings, so the
+--- label lists cross as comma-separated strings, not tables.
+--- useSub, if given, overrides the global "Use Sub Streams" property (the
+--- discovery loop auto-detects per camera whether a sub-stream exists).
+local function sendCameraConfig(camName, devId, useSub)
+    local info = RESOLVED_PER_CAMERA[camName] or { objects = {}, audio = {} }
+    C4:SendToDevice(devId, "SET_FRIGATE_CONFIG", {
+        host           = Properties[PROP_HOST] or "",
+        camera_name    = camName,
+        use_sub_stream = useSub or Properties[PROP_SUB] or "Yes",
+        object_labels  = table.concat(info.objects or {}, ","),
+        audio_labels   = table.concat(info.audio   or {}, ","),
+    })
+end
+
+--- Test accessor.
+function sendCameraConfigForTest(camName, devId, useSub) return sendCameraConfig(camName, devId, useSub) end
+
 --- Handle ADOPT_RESPONSE from a camera identifying itself.
 local function handleAdoptResponse(tParams)
     local camName = tParams and tParams.camera_name or ""
@@ -868,13 +891,7 @@ local function handleAdoptResponse(tParams)
     saveManagedCameras(managed)
 
     -- Send current config to the adopted camera
-    local host = Properties[PROP_HOST] or ""
-    local useSub = Properties[PROP_SUB] or "Yes"
-    C4:SendToDevice(devId, "SET_FRIGATE_CONFIG", {
-        host = host,
-        camera_name = camName,
-        use_sub_stream = useSub
-    })
+    sendCameraConfig(camName, devId)
 
     log(LOG_INFO, "Adopted orphan camera: " .. camName .. " (device " .. devId .. ")")
 end
@@ -896,7 +913,6 @@ local function discoverCameras()
 
         hasSubStream = hasSubStream or {}
         local managed = getManagedCameras()
-        local host = Properties[PROP_HOST] or ""
         local globalUseSub = Properties[PROP_SUB] or "Yes"
         local added = 0
         local skipped = 0
@@ -912,11 +928,7 @@ local function discoverCameras()
             if managed[camName] then
                 local devId = managed[camName].deviceId
                 if devId and devId > 0 then
-                    C4:SendToDevice(devId, "SET_FRIGATE_CONFIG", {
-                        host = host,
-                        camera_name = camName,
-                        use_sub_stream = useSub
-                    })
+                    sendCameraConfig(camName, devId, useSub)
                 end
                 skipped = skipped + 1
             else
@@ -944,11 +956,7 @@ local function discoverCameras()
 
                     saveManagedCameras(managed)
 
-                    C4:SendToDevice(deviceId, "SET_FRIGATE_CONFIG", {
-                        host = host,
-                        camera_name = camName,
-                        use_sub_stream = useSub
-                    })
+                    sendCameraConfig(camName, deviceId, useSub)
 
                     log(LOG_INFO, "Added camera: " .. camName .. " (device " .. deviceId .. ")")
                 end)

--- a/nvr-driver/driver.lua
+++ b/nvr-driver/driver.lua
@@ -318,10 +318,17 @@ end
 -- ~1/second per camera and they would flood Last Event (issue #23).
 local AUDIO_TELEMETRY = { rms = true, dBFS = true, state = true }
 
--- Fallback label sets, used when the Frigate config cannot be read. These
--- reproduce the pre-config-driven behaviour exactly.
-local FALLBACK_OBJECT_LABELS = { "person", "car", "dog", "cat" }
-local FALLBACK_AUDIO_LABELS  = { "speech", "bark", "scream", "yell", "fire_alarm" }
+-- Fallback label sets, used when the Frigate config cannot be read. This is
+-- the widest safe set for that failure case — we have no idea what the
+-- system actually detects, so err toward over-subscribing rather than
+-- silently dropping detections (the bug this change exists to fix). Do not
+-- narrow these; they mirror the canonical labels the camera driver maps.
+-- The four legacy labels (glass_breaking, siren, car_horn, music) are
+-- deliberately excluded — Frigate's /api/labels shows it has never emitted
+-- them.
+local FALLBACK_OBJECT_LABELS = { "person", "car", "dog", "cat", "package" }
+local FALLBACK_AUDIO_LABELS  = { "speech", "bark", "scream", "yell", "fire_alarm",
+                                 "glass", "shatter", "car_alarm" }
 
 RESOLVED_OBJECT_LABELS = FALLBACK_OBJECT_LABELS
 RESOLVED_AUDIO_LABELS  = FALLBACK_AUDIO_LABELS

--- a/nvr-driver/driver.lua
+++ b/nvr-driver/driver.lua
@@ -342,13 +342,42 @@ RESOLVED_AUDIO_LABELS  = FALLBACK_AUDIO_LABELS
 -- directly, so it cannot drift from the subscription list.
 AUDIO_DETECTION_TYPES = {}
 
+-- Forward declaration — subscribeFrigateTopics is defined later in this
+-- file (it needs mqttClient, which is declared even earlier), but
+-- setResolvedLabels below must call it to re-subscribe when the resolved
+-- label set changes after MQTT is already connected. Without this, a
+-- Discover Cameras that picks up a new label never reaches the broker
+-- subscription list until an unrelated MQTT reconnect (final-fix Finding A).
+local subscribeFrigateTopics
+
+--- Join a label list into a sorted, comma-joined string for cheap
+--- before/after comparison — good enough to detect "did the resolved set
+--- actually change" without needing a deep table diff.
+local function sortedJoin(list)
+    local copy = {}
+    for i, v in ipairs(list) do copy[i] = v end
+    table.sort(copy)
+    return table.concat(copy, ",")
+end
+
 --- Assign the resolved label sets and rebuild the derived whitelist.
+--- Re-subscribes to MQTT when the resolved set actually changed and a
+--- connected client exists, so the broker subscription list can never drift
+--- from the whitelist this function also maintains (final-fix Finding A).
 function setResolvedLabels(objectLabels, audioLabels)
+    local prevObj, prevAud = RESOLVED_OBJECT_LABELS, RESOLVED_AUDIO_LABELS
     if objectLabels and #objectLabels > 0 then RESOLVED_OBJECT_LABELS = objectLabels end
     if audioLabels  and #audioLabels  > 0 then RESOLVED_AUDIO_LABELS  = audioLabels  end
     AUDIO_DETECTION_TYPES = {}
     for _, l in ipairs(RESOLVED_AUDIO_LABELS) do
         if not AUDIO_TELEMETRY[l] then AUDIO_DETECTION_TYPES[l] = true end
+    end
+
+    local changed = sortedJoin(RESOLVED_OBJECT_LABELS) ~= sortedJoin(prevObj)
+        or sortedJoin(RESOLVED_AUDIO_LABELS) ~= sortedJoin(prevAud)
+
+    if changed and mqttClient and mqttConnected then
+        subscribeFrigateTopics()
     end
 end
 setResolvedLabels(FALLBACK_OBJECT_LABELS, FALLBACK_AUDIO_LABELS)
@@ -378,7 +407,7 @@ function buildSubscriptionTopics(objectLabels, audioLabels)
 end
 
 --- Subscribe to all Frigate MQTT topics.
-local function subscribeFrigateTopics()
+function subscribeFrigateTopics()
     if not mqttClient then return end
 
     local topics = buildSubscriptionTopics(RESOLVED_OBJECT_LABELS, RESOLVED_AUDIO_LABELS)

--- a/test/driver_test.lua
+++ b/test/driver_test.lua
@@ -80,6 +80,16 @@ function check(desc, ok, detail)
     if not ok then failures = failures + 1 end
 end
 
+-- In production the NVR driver pushes SET_FRIGATE_CONFIG (and this camera's
+-- labels) as soon as it pairs — before Frigate can emit any detection event
+-- for it. Registration is now per-camera (#28, #29), so simulate that same
+-- ordering here; otherwise the checks below would be asserting registration
+-- of types this camera was never told it has.
+pcall(ExecuteCommand, "SET_FRIGATE_CONFIG", {
+    host = Properties["Frigate Host"], camera_name = Properties["Camera Name"], use_sub_stream = "Yes",
+    object_labels = "person", audio_labels = "fire_alarm",
+})
+
 ------------------------------------------------------------------------
 -- Person detected: variables, events, history, Last Event
 ------------------------------------------------------------------------
@@ -321,6 +331,41 @@ check("Audio: Music is no longer registered", registeredTypes["Audio: Music"] ==
 -- registered" assertions stay valid; the assertions above deliberately check
 -- the recorded type string rather than its registration, so they survive
 -- that change. Do not convert them to registeredTypes lookups.
+
+------------------------------------------------------------------------
+-- Per-camera history registration (#28, #29)
+------------------------------------------------------------------------
+registeredTypes = {}
+pcall(ExecuteCommand, "SET_FRIGATE_CONFIG", {
+    host = "192.168.1.50", camera_name = "front_door", use_sub_stream = "Yes",
+    object_labels = "package,person", audio_labels = "bark,glass",
+})
+
+check("registers the camera's object labels",
+      registeredTypes["Package Detected"] == true and registeredTypes["Person Detected"] == true)
+check("registers the camera's audio labels",
+      registeredTypes["Audio: Bark"] == true and registeredTypes["Audio: Glass Breaking"] == true)
+check("does not register labels this camera lacks", registeredTypes["Car Detected"] == nil)
+check("still registers static types",
+      registeredTypes["Motion Detected"] == true and registeredTypes["Camera Offline"] == true)
+check("registration category is unchanged", registeredCategory == "Cameras", registeredCategory)
+check("registration subcategory is unchanged", registeredSubcategory == "Frigate", registeredSubcategory)
+
+-- Empty label lists must not wipe the static registration.
+registeredTypes = {}
+pcall(ExecuteCommand, "SET_FRIGATE_CONFIG", {
+    host = "192.168.1.50", camera_name = "bbq", use_sub_stream = "Yes",
+    object_labels = "", audio_labels = "",
+})
+check("empty labels still register the static set", registeredTypes["Motion Detected"] == true)
+
+-- An unmapped label registers its generated type, so its history can render.
+registeredTypes = {}
+pcall(ExecuteCommand, "SET_FRIGATE_CONFIG", {
+    host = "192.168.1.50", camera_name = "yard", use_sub_stream = "Yes",
+    object_labels = "bicycle", audio_labels = "",
+})
+check("unmapped label's generated type is registered", registeredTypes["Bicycle Detected"] == true)
 
 realWrite(failures == 0 and "\nALL PASS\n" or ("\n" .. failures .. " FAILURE(S)\n"))
 os.exit(failures == 0 and 0 or 1)

--- a/test/driver_test.lua
+++ b/test/driver_test.lua
@@ -279,5 +279,48 @@ check("unmapped object fires the generic event", fired["Object Detected"] == tru
 check("unmapped object records a named history entry",
       history[1] and history[1].etype == "Bicycle Detected", history[1] and history[1].etype)
 
+------------------------------------------------------------------------
+-- Package and car alarm (#28, #29)
+------------------------------------------------------------------------
+events, history = {}, {}
+local okp = pcall(ExecuteCommand, "FRIGATE_DETECTION",
+    { object_type = "package", count = 1, event_type = "new" })
+check("package detection does not raise", okp)
+check("PACKAGE_DETECTED set true", vars.PACKAGE_DETECTED == "true", vars.PACKAGE_DETECTED)
+check("PACKAGE_LAST_SEEN populated", (vars.PACKAGE_LAST_SEEN or "") ~= "")
+local pf = {}
+for _, e in ipairs(events) do pf[e] = true end
+check("fires Package Detected", pf["Package Detected"] == true)
+check("also fires Object Detected", pf["Object Detected"] == true)
+check("package history type is 'Package Detected'",
+      history[1] and history[1].etype == "Package Detected", history[1] and history[1].etype)
+
+events, history = {}, {}
+pcall(ExecuteCommand, "FRIGATE_DETECTION", { object_type = "package", count = 0, event_type = "end" })
+pf = {}
+for _, e in ipairs(events) do pf[e] = true end
+check("PACKAGE_DETECTED set false", vars.PACKAGE_DETECTED == "false", vars.PACKAGE_DETECTED)
+check("fires Package Left", pf["Package Left"] == true)
+
+events, history = {}, {}
+pcall(ExecuteCommand, "FRIGATE_AUDIO", { audio_type = "car_alarm" })
+pf = {}
+for _, e in ipairs(events) do pf[e] = true end
+check("fires Audio: Car Alarm", pf["Audio: Car Alarm"] == true)
+check("CAR_ALARM_LAST_HEARD populated", (vars.CAR_ALARM_LAST_HEARD or "") ~= "")
+check("car alarm history type is 'Audio: Car Alarm'",
+      history[1] and history[1].etype == "Audio: Car Alarm", history[1] and history[1].etype)
+
+-- Removed events must no longer be registered by the static set.
+check("Audio: Siren is no longer registered", registeredTypes["Audio: Siren"] == nil)
+check("Audio: Car Horn is no longer registered", registeredTypes["Audio: Car Horn"] == nil)
+check("Audio: Music is no longer registered", registeredTypes["Audio: Music"] == nil)
+
+-- NOTE for Task 6: registration of package/car-alarm types moves from the
+-- static list to the per-camera label list. These three "no longer
+-- registered" assertions stay valid; the assertions above deliberately check
+-- the recorded type string rather than its registration, so they survive
+-- that change. Do not convert them to registeredTypes lookups.
+
 realWrite(failures == 0 and "\nALL PASS\n" or ("\n" .. failures .. " FAILURE(S)\n"))
 os.exit(failures == 0 and 0 or 1)

--- a/test/driver_test.lua
+++ b/test/driver_test.lua
@@ -351,13 +351,36 @@ check("still registers static types",
 check("registration category is unchanged", registeredCategory == "Cameras", registeredCategory)
 check("registration subcategory is unchanged", registeredSubcategory == "Frigate", registeredSubcategory)
 
--- Empty label lists must not wipe the static registration.
+-- Empty label lists must not wipe the static registration, and — per
+-- final-fix Finding B — must register the FULL canonical set rather than
+-- nothing. "Empty" here means "unknown" (Frigate unreachable at NVR
+-- startup, or this camera missing from Frigate's config), not "this camera
+-- detects nothing"; a camera in that state still receives detections
+-- through the NVR's wildcard MQTT subscriptions, so under-registering means
+-- history gets recorded but never rendered in the Control4 app.
 registeredTypes = {}
 pcall(ExecuteCommand, "SET_FRIGATE_CONFIG", {
     host = "192.168.1.50", camera_name = "bbq", use_sub_stream = "Yes",
     object_labels = "", audio_labels = "",
 })
 check("empty labels still register the static set", registeredTypes["Motion Detected"] == true)
+check("empty labels register the full canonical object set",
+      registeredTypes["Person Detected"] == true and registeredTypes["Package Detected"] == true)
+check("empty labels register the full canonical audio set",
+      registeredTypes["Audio: Glass Breaking"] == true)
+
+-- The truly-absent case (neither object_labels nor audio_labels present in
+-- tParams at all, not even as empty strings) must behave identically — a
+-- prior reviewer flagged this exact case as untested.
+registeredTypes = {}
+pcall(ExecuteCommand, "SET_FRIGATE_CONFIG", {
+    host = "192.168.1.50", camera_name = "bbq", use_sub_stream = "Yes",
+})
+check("absent label keys still register the static set", registeredTypes["Motion Detected"] == true)
+check("absent label keys register the full canonical object set",
+      registeredTypes["Person Detected"] == true and registeredTypes["Package Detected"] == true)
+check("absent label keys register the full canonical audio set",
+      registeredTypes["Audio: Glass Breaking"] == true)
 
 -- An unmapped label registers its generated type, so its history can render.
 registeredTypes = {}

--- a/test/driver_test.lua
+++ b/test/driver_test.lua
@@ -233,5 +233,51 @@ Properties["Frigate Host"] = ""
 check("unset host returns empty string", GetNotificationAttachmentURL(1001, {}) == "")
 Properties["Frigate Host"] = savedHost
 
+------------------------------------------------------------------------
+-- Canonical label mapping and the generic path (#28, #29)
+------------------------------------------------------------------------
+check("friendlyLabel title-cases every word", friendlyLabel("fire_hydrant") == "Fire Hydrant",
+      friendlyLabel("fire_hydrant"))
+check("friendlyLabel handles a single word", friendlyLabel("bicycle") == "Bicycle")
+
+local gi = labelInfo("glass", "audio")
+check("glass maps to Audio: Glass Breaking", gi.event == "Audio: Glass Breaking", gi.event)
+check("glass uses the glass-breaking variable", gi.var == "GLASS_BREAKING_LAST_HEARD", gi.var)
+local sh = labelInfo("shatter", "audio")
+check("shatter shares the glass event", sh.event == "Audio: Glass Breaking", sh.event)
+check("shatter shares the glass variable", sh.var == "GLASS_BREAKING_LAST_HEARD", sh.var)
+local ca = labelInfo("car_alarm", "audio")
+check("car_alarm is its own event", ca.event == "Audio: Car Alarm", ca.event)
+check("car_alarm has its own variable", ca.var == "CAR_ALARM_LAST_HEARD", ca.var)
+
+check("removed label siren is no longer mapped", labelInfo("siren", "audio").event == "Audio Detected",
+      labelInfo("siren", "audio").event)
+local unk = labelInfo("didgeridoo", "audio")
+check("unmapped audio falls back to the generic event", unk.event == "Audio Detected", unk.event)
+check("unmapped audio has a friendly name", unk.friendly == "Didgeridoo", unk.friendly)
+check("unmapped audio has no variable", unk.var == nil)
+
+local bike = labelInfo("bicycle", "object")
+check("unmapped object gets a generated detected name", bike.detected == "Bicycle Detected", bike.detected)
+check("unmapped object gets a generated left name", bike.left == "Bicycle Left", bike.left)
+check("unmapped object has no variables", bike.var_bool == nil and bike.var_seen == nil)
+
+-- Title-case regression: fire_alarm history must match its registration exactly.
+events, history = {}, {}
+pcall(ExecuteCommand, "FRIGATE_AUDIO", { audio_type = "fire_alarm" })
+local fh = history[1]
+check("fire_alarm history type is title-cased", fh and fh.etype == "Audio: Fire Alarm", fh and fh.etype)
+check("fire_alarm history type is registered", fh and registeredTypes[fh.etype] == true, fh and fh.etype)
+
+-- An unmapped object must reach the generic branch that was previously dead code.
+events, history = {}, {}
+pcall(ExecuteCommand, "FRIGATE_DETECTION",
+      { object_type = "bicycle", count = 1, event_type = "new" })
+local fired = {}
+for _, e in ipairs(events) do fired[e] = true end
+check("unmapped object fires the generic event", fired["Object Detected"] == true)
+check("unmapped object records a named history entry",
+      history[1] and history[1].etype == "Bicycle Detected", history[1] and history[1].etype)
+
 realWrite(failures == 0 and "\nALL PASS\n" or ("\n" .. failures .. " FAILURE(S)\n"))
 os.exit(failures == 0 and 0 or 1)

--- a/test/nvr_test.lua
+++ b/test/nvr_test.lua
@@ -232,5 +232,31 @@ check("package count message is forwarded", pk ~= nil)
 check("forwarded with the right object type", pk and pk.params.object_type == "package",
       pk and pk.params.object_type)
 
+-- The zone branch (frigate/<camera>/<zone>/<object>) has the same
+-- resolved-set filter as the object branch above but was previously
+-- untested end to end — a mutation there would pass silently otherwise.
+sent = {}
+handleMQTTForTest("frigate/bbq/driveway/package", "1")
+local zn = findSent("FRIGATE_ZONE")
+check("zone count message is forwarded", zn ~= nil)
+check("forwarded with the right zone", zn and zn.params.zone == "driveway", zn and zn.params.zone)
+check("forwarded with the right object type", zn and zn.params.object_type == "package",
+      zn and zn.params.object_type)
+
+-- The fallback label sets are what the driver uses when Frigate's config
+-- cannot be read — pin their contents so a future edit can't silently
+-- narrow them back (that exact regression, dropping "package", is #29).
+local fbObj, fbAud = getFallbackLabels()
+check("fallback objects include package", has(fbObj, "package"))
+check("fallback objects include the original four",
+      has(fbObj, "person") and has(fbObj, "car") and has(fbObj, "dog") and has(fbObj, "cat"))
+check("fallback audio includes glass, shatter, car_alarm",
+      has(fbAud, "glass") and has(fbAud, "shatter") and has(fbAud, "car_alarm"))
+check("fallback audio includes the original five",
+      has(fbAud, "speech") and has(fbAud, "bark") and has(fbAud, "scream")
+      and has(fbAud, "yell") and has(fbAud, "fire_alarm"))
+check("fallback audio never contains telemetry",
+      not has(fbAud, "rms") and not has(fbAud, "dBFS"))
+
 realWrite(failures == 0 and "\nALL PASS\n" or ("\n" .. failures .. " FAILURE(S)\n"))
 os.exit(failures == 0 and 0 or 1)

--- a/test/nvr_test.lua
+++ b/test/nvr_test.lua
@@ -258,5 +258,33 @@ check("fallback audio includes the original five",
 check("fallback audio never contains telemetry",
       not has(fbAud, "rms") and not has(fbAud, "dBFS"))
 
+------------------------------------------------------------------------
+-- Per-camera label forwarding (#28, #29)
+------------------------------------------------------------------------
+RESOLVED_PER_CAMERA = {
+    bbq        = { objects = {"person"},          audio = {"bark","speech"} },
+    front_door = { objects = {"package","person"}, audio = {"bark","glass","speech"} },
+}
+
+sent = {}
+sendCameraConfigForTest("front_door", 1586)
+local cfg = findSent("SET_FRIGATE_CONFIG")
+check("sends SET_FRIGATE_CONFIG", cfg ~= nil)
+check("object_labels is a comma-separated string",
+      cfg and cfg.params.object_labels == "package,person", cfg and cfg.params.object_labels)
+check("audio_labels is a comma-separated string",
+      cfg and cfg.params.audio_labels == "bark,glass,speech", cfg and cfg.params.audio_labels)
+check("existing params still present",
+      cfg and cfg.params.camera_name == "front_door" and cfg.params.host ~= nil)
+
+-- A camera absent from the resolved map must still get a usable config.
+sent = {}
+sendCameraConfigForTest("unknown_cam", 1600)
+local cfg2 = findSent("SET_FRIGATE_CONFIG")
+check("unknown camera still receives config", cfg2 ~= nil)
+check("unknown camera gets empty label lists",
+      cfg2 and cfg2.params.object_labels == "" and cfg2.params.audio_labels == "",
+      cfg2 and cfg2.params.object_labels)
+
 realWrite(failures == 0 and "\nALL PASS\n" or ("\n" .. failures .. " FAILURE(S)\n"))
 os.exit(failures == 0 and 0 or 1)

--- a/test/nvr_test.lua
+++ b/test/nvr_test.lua
@@ -259,6 +259,55 @@ check("fallback audio never contains telemetry",
       not has(fbAud, "rms") and not has(fbAud, "dBFS"))
 
 ------------------------------------------------------------------------
+-- Re-subscription when resolved labels change (final-fix Finding A)
+--
+-- setResolvedLabels() must push the updated set to the broker when MQTT is
+-- already connected — otherwise the subscription list (fixed at connect
+-- time) can permanently disagree with the whitelist it also derives, and a
+-- label added via Discover Cameras never reaches Control4 until an
+-- unrelated MQTT reconnect happens to occur.
+------------------------------------------------------------------------
+local mqttSubscribeCalls = {}
+local mqttOnConnectCb = nil
+function C4:MQTT(clientId)
+    local client = {}
+    function client:SetUsernameAndPassword(u, p) end
+    function client:OnConnect(cb) mqttOnConnectCb = cb end
+    function client:OnDisconnect(cb) end
+    function client:OnMessage(cb) end
+    function client:Connect(host, port, keepalive) end
+    function client:Disconnect() end
+    function client:Subscribe(topic, qos) mqttSubscribeCalls[#mqttSubscribeCalls + 1] = topic end
+    function client:ReasonCodeToString(code) return tostring(code) end
+    return client
+end
+
+Properties["MQTT Broker"] = "192.168.1.60"
+
+-- Known baseline before connecting, independent of whatever earlier tests
+-- above left RESOLVED_OBJECT_LABELS/RESOLVED_AUDIO_LABELS set to.
+setResolvedLabels({"person", "car"}, {"bark"})
+
+ExecuteCommand("ReconnectMQTT", {})
+check("MQTT client created on ReconnectMQTT", mqttOnConnectCb ~= nil)
+
+mqttOnConnectCb(nil, 0, nil, nil)  -- simulate broker CONNACK (reasonCode 0)
+check("initial connect subscribes using the resolved set", #mqttSubscribeCalls > 0, #mqttSubscribeCalls)
+
+mqttSubscribeCalls = {}
+setResolvedLabels({"person", "car"}, {"bark"})
+check("resolving an identical label set does not re-subscribe",
+      #mqttSubscribeCalls == 0, #mqttSubscribeCalls)
+
+mqttSubscribeCalls = {}
+setResolvedLabels({"person", "car", "bicycle"}, {"bark"})
+check("resolving a changed label set re-subscribes", #mqttSubscribeCalls > 0, #mqttSubscribeCalls)
+check("re-subscription includes the new label's object-count topic",
+      has(mqttSubscribeCalls, "frigate/+/bicycle"))
+check("re-subscription includes the new label's zone-count topic",
+      has(mqttSubscribeCalls, "frigate/+/+/bicycle"))
+
+------------------------------------------------------------------------
 -- Per-camera label forwarding (#28, #29)
 ------------------------------------------------------------------------
 RESOLVED_PER_CAMERA = {

--- a/test/nvr_test.lua
+++ b/test/nvr_test.lua
@@ -151,5 +151,45 @@ check("loitering still detected", loiter ~= nil)
 check("loitering zone forwarded", loiter and loiter.params.zone == "driveway",
       loiter and loiter.params.zone)
 
+------------------------------------------------------------------------
+-- Label parsing from Frigate config (#28, #29)
+------------------------------------------------------------------------
+local CFG = [[
+{"objects":{"track":["person"]},
+ "audio":{"enabled":true,"listen":["bark","speech"]},
+ "cameras":{
+   "bbq":{"objects":{"track":["person"]},"audio":{"enabled":true,"listen":["bark","speech"]}},
+   "front_door":{"objects":{"track":["person","package"]},"audio":{"enabled":true,"listen":["bark","speech","glass"]}},
+   "gate":{"objects":{"track":["person","car"]},"audio":{"enabled":true,"listen":["bark","speech"]}}}}
+]]
+
+local function joined(t) return table.concat(t, ",") end
+
+local objU, audU, perCam = parseDetectionLabels(CFG)
+check("parseDetectionLabels returns a result", objU ~= nil)
+check("object union spans all cameras", joined(objU) == "car,package,person", objU and joined(objU))
+check("audio union spans all cameras", joined(audU) == "bark,glass,speech", audU and joined(audU))
+check("per-camera objects for front_door",
+      perCam and joined(perCam.front_door.objects) == "package,person",
+      perCam and perCam.front_door and joined(perCam.front_door.objects))
+check("per-camera audio for bbq excludes glass",
+      perCam and joined(perCam.bbq.audio) == "bark,speech",
+      perCam and perCam.bbq and joined(perCam.bbq.audio))
+
+-- A camera with no audio block still contributes its objects.
+local CFG2 = [[
+{"objects":{"track":["person"]},"audio":{"listen":["bark"]},
+ "cameras":{"cam1":{"objects":{"track":["person","dog"]}}}}
+]]
+local o2, a2, p2 = parseDetectionLabels(CFG2)
+check("camera without audio block still parses", o2 ~= nil)
+check("its objects are included", o2 and joined(o2) == "dog,person", o2 and joined(o2))
+
+-- Malformed and empty payloads return nil rather than raising.
+local ok3 = pcall(parseDetectionLabels, "not json")
+check("malformed payload does not raise", ok3)
+check("malformed payload returns nil", select(1, parseDetectionLabels("not json")) == nil)
+check("empty payload returns nil", select(1, parseDetectionLabels("")) == nil)
+
 realWrite(failures == 0 and "\nALL PASS\n" or ("\n" .. failures .. " FAILURE(S)\n"))
 os.exit(failures == 0 and 0 or 1)

--- a/test/nvr_test.lua
+++ b/test/nvr_test.lua
@@ -191,5 +191,46 @@ check("malformed payload does not raise", ok3)
 check("malformed payload returns nil", select(1, parseDetectionLabels("not json")) == nil)
 check("empty payload returns nil", select(1, parseDetectionLabels("")) == nil)
 
+------------------------------------------------------------------------
+-- Subscriptions derived from resolved labels (#28, #29)
+------------------------------------------------------------------------
+local function has(list, v)
+    for _, x in ipairs(list) do if x == v then return true end end
+    return false
+end
+
+local topics = buildSubscriptionTopics({"person","package"}, {"bark","glass"})
+check("subscribes to object counts", has(topics, "frigate/+/person") and has(topics, "frigate/+/package"))
+check("subscribes to zone counts", has(topics, "frigate/+/+/person") and has(topics, "frigate/+/+/package"))
+check("subscribes to audio labels", has(topics, "frigate/+/audio/bark") and has(topics, "frigate/+/audio/glass"))
+check("still subscribes to frigate/events", has(topics, "frigate/events"))
+check("still subscribes to motion", has(topics, "frigate/+/motion"))
+
+-- The #23 protection: telemetry must never be subscribed to, whatever the config says.
+check("never subscribes to audio rms", not has(topics, "frigate/+/audio/rms"))
+check("never subscribes to audio dBFS", not has(topics, "frigate/+/audio/dBFS"))
+local dirty = buildSubscriptionTopics({"person"}, {"bark","rms","dBFS"})
+check("telemetry labels are filtered out of audio subscriptions",
+      not has(dirty, "frigate/+/audio/rms") and not has(dirty, "frigate/+/audio/dBFS"))
+check("no bare wildcard subscription", not has(topics, "frigate/+/+") and not has(topics, "frigate/#"))
+
+-- Whitelist and subscriptions come from one source and cannot disagree.
+setResolvedLabels({"person","package"}, {"bark","glass"})
+check("whitelist matches resolved audio labels",
+      AUDIO_DETECTION_TYPES.bark == true and AUDIO_DETECTION_TYPES.glass == true)
+check("whitelist excludes unresolved audio labels", AUDIO_DETECTION_TYPES.speech == nil)
+check("whitelist never contains telemetry",
+      AUDIO_DETECTION_TYPES.rms == nil and AUDIO_DETECTION_TYPES.dBFS == nil)
+
+-- An object label outside the old four must now be forwarded.
+-- Uses "bbq", the only camera registered in the C4:PersistGetValue mock above;
+-- an unmanaged camera name would be dropped by sendToCamera regardless of label.
+sent = {}
+handleMQTTForTest("frigate/bbq/package", "1")
+local pk = findSent("FRIGATE_DETECTION")
+check("package count message is forwarded", pk ~= nil)
+check("forwarded with the right object type", pk and pk.params.object_type == "package",
+      pk and pk.params.object_type)
+
 realWrite(failures == 0 and "\nALL PASS\n" or ("\n" .. failures .. " FAILURE(S)\n"))
 os.exit(failures == 0 and 0 or 1)


### PR DESCRIPTION
Fixes #28 and #29. **Deliberately not released** — see "Before merging" below.

## The problem

The driver hardcoded which Frigate detection labels it subscribed to over MQTT — four object types and nine audio types — in two independent places per detection kind. Frigate's real labels come from its own per-camera configuration. The two drifted, silently.

On the live reference system that meant `package` detections at the front door never reached Control4 at all: no event, no history entry, no log line. Same for `glass`, `shatter` and `car_alarm`. Meanwhile the driver subscribed to `siren`, `music`, `car_horn` and `glass_breaking`, which `/api/labels` shows Frigate has never once emitted.

A third symptom shared the root cause: `handleAudio()` built its history type by capitalising only the first character, recording `Audio: Fire alarm` while the registration said `Audio: Fire Alarm`. Control4 renders history only on an exact match, so those entries were stored and never displayed — the same failure class as #24.

## What changed

- **Subscriptions and the handler whitelist are both generated from one label set** resolved from Frigate's config at discovery, including per-camera overrides. They cannot disagree because there is only one list.
- **One canonical mapping table** feeds the fired event, the recorded history type *and* the history registration, so the title-case class of bug is structurally impossible rather than merely fixed.
- **Unmapped labels route to the generic `Object Detected` / `Audio Detected`** with a properly named history entry instead of being dropped. This activates a branch that has existed since v0.7.0 and could never previously execute.
- **History registration is per-camera** — each camera registers the static types plus exactly the labels the NVR told it about.
- **`package` and `car_alarm` are first-class**: `Package Detected` (30), `Package Left` (31), `Audio: Car Alarm` (32), with `PACKAGE_DETECTED`, `PACKAGE_LAST_SEEN`, `CAR_ALARM_LAST_HEARD`.
- **The resolved label sets are logged at INFO**, because every defect here was invisible partly because nothing ever stated what the driver was listening for.

### Breaking

`Audio: Siren`, `Audio: Car Horn` and `Audio: Music` and their `_LAST_HEARD` variables are removed — Frigate has never emitted those labels. If some configuration does, the detection still arrives via the generic `Audio Detected` path with correct history, but programming bound to the three removed events stops firing. Event ids 22–24 are left **vacant**; nothing was renumbered, so no existing event identity moves.

## Before merging

- **CI has never run the LuaJIT test switch.** This branch moved the harnesses from the system `lua` to `luajit`, matching what DriverWorks actually runs. It passes locally on LuaJIT 2.1 / arm64 macOS; the runner installs `luajit` from apt on x86 Ubuntu. This PR exists partly so that gets validated on a clean machine first.
- **#30 is open and blocks release, not merge.** Per-camera registration is lost on a solo camera-driver restart for *non-canonical* labels — `bicycle`, `truck`, Frigate+ `amazon`/`ups`/`fedex`. Canonical labels recover, because an empty label list now registers the full canonical set. The durable fix is to persist the label list in the camera driver.
- **No version bump, no tag, no release.** Camera stays v44, NVR v49, `DRIVER_RELEASE` v0.9.0-rc.1. This project auto-installs GitHub releases, so nothing here can reach users.

## How it was built and reviewed

Seven tasks, each implemented by a separate agent and independently reviewed, then a whole-branch review. Reviewers used mutation testing throughout — breaking the implementation to confirm a test actually catches it.

That caught four defects in the plan itself: a missing third `SET_FRIGATE_CONFIG` send site; a dropped per-camera `useSub` value that would have degraded every camera's stream; an `EVENT_IDS` gate that would have left the new events unable to fire; and fallback label lists too narrow to be safe.

The whole-branch review caught the one that mattered most: **resolved labels never reached the MQTT subscription list.** `setResolvedLabels` rebuilt the whitelist but never re-subscribed, so subscriptions stayed at the fallback while the whitelist held the resolved set — the exact drift this branch exists to eliminate. It was invisible on the reference system because its fallback happens to be a superset of what that Frigate tracks. Fixed in e3dc09d, along with an empty-label case that registered *less* than before the branch.

## Tests

`test/nvr_test.lua` and `test/driver_test.lua`, run under LuaJIT in CI. 55 and 79 assertions.
